### PR TITLE
Update function_calling.ipynb

### DIFF
--- a/backend/function_calling.ipynb
+++ b/backend/function_calling.ipynb
@@ -192,7 +192,7 @@
     "Note that `--tool-call-parser` defines the parser used to interpret responses. Currently supported parsers include:\n",
     "\n",
     "- llama3: Llama 3.1 / 3.2 / 3.3 (e.g. meta-llama/Llama-3.1-8B-Instruct, meta-llama/Llama-3.2-1B-Instruct, meta-llama/Llama-3.3-70B-Instruct).\n",
-    "- llama4: Llama 4 (e.g. meta-llama/Llama-4-Scout-17B-16E-Instruct).\n",
+    "- pythonic: Llama 4 (e.g. meta-llama/Llama-4-Scout-17B-16E-Instruct).\n",
     "- mistral: Mistral (e.g. mistralai/Mistral-7B-Instruct-v0.3, mistralai/Mistral-Nemo-Instruct-2407, mistralai/\n",
     "Mistral-Nemo-Instruct-2407, mistralai/Mistral-7B-v0.3).\n",
     "- qwen25: Qwen 2.5 (e.g. Qwen/Qwen2.5-1.5B-Instruct, Qwen/Qwen2.5-7B-Instruct) and QwQ (i.e. Qwen/QwQ-32B). Especially, for QwQ, we can enable the reasoning parser together with tool call parser, details about reasoning parser can be found in [reasoning parser](https://docs.sglang.ai/backend/separate_reasoning.html).\n",


### PR DESCRIPTION
Fixing issue in documentation: llama4 is not a correct tool call parser. If you try to execute you would get this error:
launch_server.py: error: argument --tool-call-parser: invalid choice: 'llama4' (choose from 'qwen25', 'mistral', 'llama3', 'deepseekv3', 'pythonic')

[Issue](https://github.com/sgl-project/sgl-project.github.io/issues/17)

Signed-off-by: Adrian Garcia <adrian.garcia@inceptionai.ai>