### PR TITLE
docs: clarify tensor dump output behavior in Eagle mode

### DIFF
--- a/_sources/advanced_features/server_arguments.md
+++ b/_sources/advanced_features/server_arguments.md
@@ -483,7 +483,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 ## Debug tensor dumps
 | Argument | Description | Defaults | Options |
 | --- | --- | --- | --- |
-| `--debug-tensor-dump-output-folder` | The output folder for dumping tensors. | `None` | Type: str |
+| `--debug-tensor-dump-output-folder` | The output folder for dumping tensors.In Eagle mode, tensor outputs from draft and target models are stored in separate subdirectories ('draft' and 'target'). | `None` | Type: str |
 | `--debug-tensor-dump-layers` | The layer ids to dump. Dump all layers if not specified. | `None` | Type: JSON list |
 | `--debug-tensor-dump-input-file` | The input filename for dumping tensors | `None` | Type: str |
 | `--debug-tensor-dump-inject` | Inject the outputs from jax as the input of every layer. | `False` | Type: str |

--- a/advanced_features/server_arguments.html
+++ b/advanced_features/server_arguments.html
@@ -2498,7 +2498,7 @@ python<span class="w"> </span>-m<span class="w"> </span>sglang.launch_server<spa
 </thead>
 <tbody>
 <tr class="row-even"><td><p><code class="docutils literal notranslate"><span class="pre">--debug-tensor-dump-output-folder</span></code></p></td>
-<td><p>The output folder for dumping tensors.</p></td>
+<td><p>The output folder for dumping tensors.In Eagle mode, tensor outputs from draft and target models are stored in separate subdirectories ('draft' and 'target').</p></td>
 <td><p><code class="docutils literal notranslate"><span class="pre">None</span></code></p></td>
 <td><p>Type: str</p></td>
 </tr>

--- a/markdown/advanced_features/server_arguments.md
+++ b/markdown/advanced_features/server_arguments.md
@@ -483,7 +483,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 ## Debug tensor dumps
 | Argument | Description | Defaults | Options |
 | --- | --- | --- | --- |
-| `--debug-tensor-dump-output-folder` | The output folder for dumping tensors. | `None` | Type: str |
+| `--debug-tensor-dump-output-folder` | The output folder for dumping tensors.In Eagle mode, tensor outputs from draft and target models are stored in separate subdirectories ('draft' and 'target'). | `None` | Type: str |
 | `--debug-tensor-dump-layers` | The layer ids to dump. Dump all layers if not specified. | `None` | Type: JSON list |
 | `--debug-tensor-dump-input-file` | The input filename for dumping tensors | `None` | Type: str |
 | `--debug-tensor-dump-inject` | Inject the outputs from jax as the input of every layer. | `False` | Type: str |


### PR DESCRIPTION

## Summary
Add description that tensor outputs are separated into 'draft' and 'target' subdirectories when Eagle mode is enabled.
This PR updates the documentation for `--debug-tensor-dump-output-folder` to clarify its behavior in Eagle mode.
#27 
## Motivation

In Eagle mode, tensor outputs from the target and draft models are stored in separate subdirectories ("target" and "draft"). This behavior was previously undocumented, which may cause confusion when analyzing dumped tensors.

## Modifications

- Update the help description of `--debug-tensor-dump-output-folder`
- Add clarification that tensor outputs are separated into `target/` and `draft/` subdirectories in Eagle mode

## Related Pull Request

- Code change: https://github.com/sgl-project/sglang/pull/21694

## Additional Notes

This is a documentation-only change and does not affect model behavior or performance.